### PR TITLE
add a multifile decorator for the serialization methods #91

### DIFF
--- a/kglab/decorators.py
+++ b/kglab/decorators.py
@@ -1,48 +1,91 @@
-from functools import wraps, reduce
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+######################################################################
+## Decorator to handle multiple paths
+
 from copy import deepcopy
-import inspect
+#from functools import reduce
+from functools import wraps
 from glob import glob
-from pathlib import Path
+import inspect
+import pathlib
+import typing
+import urlpath  # type: ignore
 
-# decorator to handle multiple paths
-def multifile(param_name="path"):
+
+def _test_path (
+    path: typing.Union[ pathlib.Path, urlpath.URL ]
+    ) -> bool:
     """
-    Creates a wrapper around read function to read multiple file given a pattern with at least one * in the path.
+Semi-private function to test whether the given path parameter is an
+instance of `pathlib.Path`, `urlpath.URL`, or a related class.
+
+    path:
+parameter to be tested
+
+    returns:
+test condition
+    """
+    return isinstance(path, (pathlib.Path, urlpath.URL))
+
+
+def multifile (
+    param_name: str = "path",
+    ) -> typing.Any:
+    """
+Creates a wrapper around a read function to read multiple files, given
+a glob pattern with at least one wildcard in the path.
+
+    param_name:
+parameter to be overloaded
+
+    returns:
+constructed decorator
     """
 
-    def decorator(f):
+    def decorator (
+        f: typing.Any,
+        ) -> typing.Any:
         sig = inspect.signature(f)
+
         if param_name not in sig.parameters:
             raise ValueError(
                 f"Reader function {f.__name__} has no parameter '{param_name}'"
             )
 
         @wraps(f)
-        def wrapper(*args, **kwargs):
+        def wrapper (  # pylint: disable=R1710
+            *args: typing.Any,
+             **kwargs: typing.Any,
+             ) -> typing.Any:
             bound_arguments = sig.bind(*args, **kwargs)
-
             bound_arguments.apply_defaults()
 
             path = bound_arguments.arguments[param_name]
+            path_list: typing.List = []
 
-            # If * not in path then let the default function handle it.
-            # We are only interested if the path has * in it
+            # if `*` is not in the path then simply let the default
+            # function handle it
             if isinstance(path, str):
                 if "*" not in path:
                     return f(*args, **kwargs)
-                else:
-                    # Else, create a glob out of it
-                    path_list = glob(path)
 
-            # Let default function handle single Path objects
-            elif isinstance(path, Path):
+                # initialize the path list with a parsed glob
+                path_list = glob(path)
+
+            # also handle single Path objects by the default function
+            elif _test_path(path):
                 return f(*args, **kwargs)
 
-            # Handle a list of Path objects
-            elif isinstance(path, (list)):
-                path_list = []
+            # no files were found in the given pattern so raise error
+            if len(path_list) == 0:
+                raise ValueError(f"No files found in given path list: {path}")
+
+            # handle a list of Path objects
+            if isinstance(path, (list)):
                 for p in path:
-                    if isinstance(p, Path):
+                    if _test_path(path):
                         path_list.append(p)
                     else:
                         raise ValueError(f"Invalid path: {p}")
@@ -51,29 +94,29 @@ def multifile(param_name="path"):
                     f"{path} is not a valid string, Path, or list of Paths"
                 )
 
-            # No files found given the pattern so raise error
-            if len(path_list) == 0:
-                raise ValueError(f"No files found given pattern : {path}")
-
-            # Store the parsed clumpers here
+            # store the parsed clumpers here
             # collected_clumpers = []
 
-            # Iterate each path in the glob
+            # iterate through each path in the glob
             for p in path_list:
-                # Set the path variable
+                # set the path variable
                 bound_arguments.arguments[param_name] = str(p)
-                # Call the underlying reader function
-                clumper = f(*bound_arguments.args, **deepcopy(bound_arguments.kwargs))
-                # Collect the clumper
+
+                # call the underlying reader function
+                clumper = f(*bound_arguments.args, **deepcopy(bound_arguments.kwargs))  # pylint: disable=W0612
+
+                # collect the clumper
                 # collected_clumpers.append(clumper)
 
-            # TODO: Not required since load function adds to existing knowlege graph. Delete commented code on confirmation
+            # TODO: Not required since load function adds to existing  # pylint: disable=W0511
+            # knowledge graph. Delete commented code on confirmation
+
             # # Only one object found
             # if len(collected_clumpers) == 1:
             #     return collected_clumpers[0]
             # # More than one object found
             # elif len(collected_clumpers) > 1:
-            #     # Combine them by concating their dict
+            #     # Combine them by concatenating their dict
             #     ic(collected_clumpers)
             #     # return reduce(lambda a, b: a.concat(b), collected_clumpers)
 

--- a/kglab/decorators.py
+++ b/kglab/decorators.py
@@ -1,0 +1,82 @@
+from functools import wraps, reduce
+from copy import deepcopy
+import inspect
+from glob import glob
+from pathlib import Path
+
+# decorator to handle multiple paths
+def multifile(param_name="path"):
+    """
+    Creates a wrapper around read function to read multiple file given a pattern with at least one * in the path.
+    """
+
+    def decorator(f):
+        sig = inspect.signature(f)
+        if param_name not in sig.parameters:
+            raise ValueError(
+                f"Reader function {f.__name__} has no parameter '{param_name}'"
+            )
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            bound_arguments = sig.bind(*args, **kwargs)
+
+            bound_arguments.apply_defaults()
+
+            path = bound_arguments.arguments[param_name]
+
+            # If * not in path then let the default function handle it.
+            # We are only interested if the path has * in it
+            if isinstance(path, str):
+                if "*" not in path:
+                    return f(*args, **kwargs)
+                else:
+                    # Else, create a glob out of it
+                    path_list = glob(path)
+
+            # Let default function handle single Path objects
+            elif isinstance(path, Path):
+                return f(*args, **kwargs)
+
+            # Handle a list of Path objects
+            elif isinstance(path, (list)):
+                path_list = []
+                for p in path:
+                    if isinstance(p, Path):
+                        path_list.append(p)
+                    else:
+                        raise ValueError(f"Invalid path: {p}")
+            else:
+                raise ValueError(
+                    f"{path} is not a valid string, Path, or list of Paths"
+                )
+
+            # No files found given the pattern so raise error
+            if len(path_list) == 0:
+                raise ValueError(f"No files found given pattern : {path}")
+
+            # Store the parsed clumpers here
+            # collected_clumpers = []
+
+            # Iterate each path in the glob
+            for p in path_list:
+                # Set the path variable
+                bound_arguments.arguments[param_name] = str(p)
+                # Call the underlying reader function
+                clumper = f(*bound_arguments.args, **deepcopy(bound_arguments.kwargs))
+                # Collect the clumper
+                # collected_clumpers.append(clumper)
+
+            # TODO: Not required since load function adds to existing knowlege graph. Delete commented code on confirmation
+            # # Only one object found
+            # if len(collected_clumpers) == 1:
+            #     return collected_clumpers[0]
+            # # More than one object found
+            # elif len(collected_clumpers) > 1:
+            #     # Combine them by concating their dict
+            #     ic(collected_clumpers)
+            #     # return reduce(lambda a, b: a.concat(b), collected_clumpers)
+
+        return wrapper
+
+    return decorator

--- a/kglab/kglab.py
+++ b/kglab/kglab.py
@@ -30,9 +30,92 @@ import traceback
 import typing
 import urlpath  # type: ignore
 
+from functools import wraps, reduce
+from copy import deepcopy
+import inspect
+from glob import glob
+from pathlib import Path
+
 if get_gpu_count() > 0:
     import cudf  # type: ignore # pylint: disable=E0401
 
+
+# decorator to handle multiple paths
+def multifile(param_name="path"):
+    """
+    Creates a wrapper around read function to read multiple file given a pattern with at least one * in the path.
+    """
+
+    def decorator(f):
+        sig = inspect.signature(f)
+        if param_name not in sig.parameters:
+            raise ValueError(
+                f"Reader function {f.__name__} has no parameter '{param_name}'"
+            )
+
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            bound_arguments = sig.bind(*args, **kwargs)
+
+            bound_arguments.apply_defaults()
+
+            path = bound_arguments.arguments[param_name]
+
+            # If * not in path then let the default function handle it.
+            # We are only interested if the path has * in it
+            if isinstance(path, str):
+                if "*" not in path:
+                    return f(*args, **kwargs)
+                else:
+                    # Else, create a glob out of it
+                    path_list = glob(path)
+
+            # Let default function handle single Path objects
+            elif isinstance(path, Path):
+                return f(*args, **kwargs)
+
+            # Handle a list of Path objects
+            elif isinstance(path, (list)):
+                path_list = []
+                for p in path:
+                    if isinstance(p, Path):
+                        path_list.append(p)
+                    else:
+                        raise ValueError(f"Invalid path: {p}")
+            else:
+                raise ValueError(
+                    f"{path} is not a valid string, Path, or list of Paths"
+                )
+
+            # No files found given the pattern so raise error
+            if len(path_list) == 0:
+                raise ValueError(f"No files found given pattern : {path}")
+
+            # Store the parsed clumpers here
+            # collected_clumpers = []
+
+            # Iterate each path in the glob
+            for p in path_list:
+                # Set the path variable
+                bound_arguments.arguments[param_name] = str(p)
+                # Call the underlying reader function
+                clumper = f(*bound_arguments.args, **deepcopy(bound_arguments.kwargs))
+                # Collect the clumper
+                # collected_clumpers.append(clumper)
+
+            # TODO: Not required since load function adds to existing knowlege graph. Delete commented code on confirmation
+            # # Only one object found
+            # if len(collected_clumpers) == 1:
+            #     return collected_clumpers[0]
+            # # More than one object found
+            # elif len(collected_clumpers) > 1:
+            #     # Combine them by concating their dict
+            #     ic(collected_clumpers)
+            #     # return reduce(lambda a, b: a.concat(b), collected_clumpers)
+
+        return wrapper
+
+    return decorator
 
 class KnowledgeGraph:
     """
@@ -456,7 +539,7 @@ a string as a file name or URL to a file reference
 
         return filename
 
-
+    @multifile()
     def load_rdf (
         self,
         path: IOPathLike,

--- a/kglab/kglab.py
+++ b/kglab/kglab.py
@@ -6,6 +6,7 @@
 
 from kglab.pkg_types import PathLike, IOPathLike, GraphLike, RDF_Node
 from kglab.util import get_gpu_count
+from kglab.decorators import multifile
 from kglab.version import _check_version
 _check_version()
 
@@ -30,92 +31,10 @@ import traceback
 import typing
 import urlpath  # type: ignore
 
-from functools import wraps, reduce
-from copy import deepcopy
-import inspect
-from glob import glob
-from pathlib import Path
-
 if get_gpu_count() > 0:
     import cudf  # type: ignore # pylint: disable=E0401
 
 
-# decorator to handle multiple paths
-def multifile(param_name="path"):
-    """
-    Creates a wrapper around read function to read multiple file given a pattern with at least one * in the path.
-    """
-
-    def decorator(f):
-        sig = inspect.signature(f)
-        if param_name not in sig.parameters:
-            raise ValueError(
-                f"Reader function {f.__name__} has no parameter '{param_name}'"
-            )
-
-        @wraps(f)
-        def wrapper(*args, **kwargs):
-            bound_arguments = sig.bind(*args, **kwargs)
-
-            bound_arguments.apply_defaults()
-
-            path = bound_arguments.arguments[param_name]
-
-            # If * not in path then let the default function handle it.
-            # We are only interested if the path has * in it
-            if isinstance(path, str):
-                if "*" not in path:
-                    return f(*args, **kwargs)
-                else:
-                    # Else, create a glob out of it
-                    path_list = glob(path)
-
-            # Let default function handle single Path objects
-            elif isinstance(path, Path):
-                return f(*args, **kwargs)
-
-            # Handle a list of Path objects
-            elif isinstance(path, (list)):
-                path_list = []
-                for p in path:
-                    if isinstance(p, Path):
-                        path_list.append(p)
-                    else:
-                        raise ValueError(f"Invalid path: {p}")
-            else:
-                raise ValueError(
-                    f"{path} is not a valid string, Path, or list of Paths"
-                )
-
-            # No files found given the pattern so raise error
-            if len(path_list) == 0:
-                raise ValueError(f"No files found given pattern : {path}")
-
-            # Store the parsed clumpers here
-            # collected_clumpers = []
-
-            # Iterate each path in the glob
-            for p in path_list:
-                # Set the path variable
-                bound_arguments.arguments[param_name] = str(p)
-                # Call the underlying reader function
-                clumper = f(*bound_arguments.args, **deepcopy(bound_arguments.kwargs))
-                # Collect the clumper
-                # collected_clumpers.append(clumper)
-
-            # TODO: Not required since load function adds to existing knowlege graph. Delete commented code on confirmation
-            # # Only one object found
-            # if len(collected_clumpers) == 1:
-            #     return collected_clumpers[0]
-            # # More than one object found
-            # elif len(collected_clumpers) > 1:
-            #     # Combine them by concating their dict
-            #     ic(collected_clumpers)
-            #     # return reduce(lambda a, b: a.concat(b), collected_clumpers)
-
-        return wrapper
-
-    return decorator
 
 class KnowledgeGraph:
     """

--- a/kglab/kglab.py
+++ b/kglab/kglab.py
@@ -4,9 +4,9 @@
 ######################################################################
 ## kglab - core classes
 
+from kglab.decorators import multifile
 from kglab.pkg_types import PathLike, IOPathLike, GraphLike, RDF_Node
 from kglab.util import get_gpu_count
-from kglab.decorators import multifile
 from kglab.version import _check_version
 _check_version()
 
@@ -458,6 +458,7 @@ a string as a file name or URL to a file reference
 
         return filename
 
+
     @multifile()
     def load_rdf (
         self,
@@ -475,7 +476,7 @@ Throws `TypeError` whenever a format parser plugin encounters a syntax error.
 Note: this adds relations to an RDF graph, although it does not overwrite the existing RDF graph.
 
     path:
-must be a file name (str) or a path object (not a URL) to a local file reference; or a [*readable, file-like object*](https://docs.python.org/3/glossary.html#term-file-object)
+must be a file name (str) or a path object (not a URL) to a local file reference (which may be a glob with a wildcard); or a [*readable, file-like object*](https://docs.python.org/3/glossary.html#term-file-object)
 
     format:
 serialization format, defaults to Turtle triples; see `_RDF_FORMAT` for a list of default formats, which can be extended with plugins – excluding the `"json-ld"` format; otherwise this throws a `TypeError` exception

--- a/tests/test_knowlegegraph.py
+++ b/tests/test_knowlegegraph.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Unit tests for KnowledgeGraph class."""
+import sys ; sys.path.insert(0, "../kglab/kglab")
+
+from icecream import ic
+import kglab
+
+
+def test_single_file_load_rdf ():
+    """
+load rdf from a single file
+    """
+
+    # create a KnowledgeGraph object
+    kg = kglab.KnowledgeGraph()
+
+    # load RDF from a file
+    kg.load_rdf("../dat/gorm.ttl", format="ttl")
+    measure = kglab.Measure()
+
+    measure.measure_graph(kg)
+    edge_count = measure.get_edge_count()
+    node_count = measure.get_node_count()
+
+    assert edge_count == 25
+    assert node_count == 15
+
+def test_multiple_file_load_rdf():
+    """
+load rdf from a multiple files using wildcard expression
+    """
+
+    # create a KnowledgeGraph object
+    kg = kglab.KnowledgeGraph()
+
+    # load RDF from a file1 into kg
+    kg.load_rdf("../dat/gorm.ttl", format="ttl")
+
+    # load RDF from a file2 into kg
+    kg.load_rdf("../dat/nom.ttl", format="ttl")
+
+    measure = kglab.Measure()
+    measure.measure_graph(kg)
+    sequential_edge_count = measure.get_edge_count()
+    sequential_node_count = measure.get_node_count()
+
+
+    kg_multifile = kglab.KnowledgeGraph()
+
+    # load RDF from all files(file1 and file2) matching the expression into kg
+    kg_multifile.load_rdf("../dat/*m.ttl", format="ttl")
+
+    measure.reset()
+    measure.measure_graph(kg_multifile)
+    multifile_edge_count = measure.get_edge_count()
+    multifile_node_count = measure.get_node_count()
+
+    # ic(multifile_edge_count)
+    # ic(multifile_node_count)
+    assert multifile_edge_count == sequential_edge_count
+    assert multifile_node_count == sequential_node_count
+


### PR DESCRIPTION
@ceteri 
I have added multifile support for `load_rdf` . 

- [x] modify multifile decorator as per our requirement. 
- [x] apply decorator on `load_rdf` function
- [x] add test cases for single file/multifile `load_rdf`
- [ ] apply decorator on load_jsonld()
- [ ] apply decorator on load_parquet()

Please review.