### PR TITLE
Fix CI: the input device is not a TTY

### DIFF
--- a/.github/workflows/docker-demo.yml
+++ b/.github/workflows/docker-demo.yml
@@ -18,4 +18,4 @@ jobs:
         run: docker logs kglab-notebooks
       - name: Test all notebooks in the examples/ folder can run
         run: |
-          docker exec -it kglab-notebooks bash -c 'pip install treon && treon work/examples/'
+          docker exec -i kglab-notebooks bash -c 'pip install treon && treon work/examples/'


### PR DESCRIPTION
The Github Actions chicken and egg problem means I didn't see this issue until later.
For example this run https://github.com/DerwenAI/kglab/runs/2540865279 failed with 
![image](https://user-images.githubusercontent.com/7823843/117626688-ab69e300-b177-11eb-9c4b-08e294559366.png)

