### PR TITLE
Adding pre-commit to Continuous Integration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,29 @@
-name: docker-demo
+name: CI
 
 on:
   pull_request:
   push:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
       - uses: satackey/action-docker-layer-caching@v0.0.11
         continue-on-error: true
       - name: Build the stack
         run: docker-compose up -d
+
       - name: Check running containers
         run: docker ps -a
+
       - name: Check logs
         run: docker logs kglab-notebooks
+
+      - uses: pre-commit/action@v2.0.2
       - name: Test all notebooks in the examples/ folder can run
         run: |
           docker exec -i kglab-notebooks bash -c 'pip install pytest nbmake && pytest --nbmake work/examples/*.ipynb'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,7 @@
 default_stages: [commit, push]
 default_language_version:
     python: python3
+exclude: "dat"
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
@@ -13,13 +14,11 @@ repos:
     -   id: check-merge-conflict
     -   id: debug-statements
     -   id: detect-private-key
-    -   id: no-commit-to-branch
-        args: [ "--branch", "main" ]
 -   repo: https://github.com/PyCQA/bandit
     rev: 1.7.0
     hooks:
     -   id: bandit # security vulnerabilities
-        args: [ "--exclude", "setup.py,test.py" ]
+        args: [ "--exclude", "setup.py,bin,test.py" ]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.812
     hooks:
@@ -31,3 +30,11 @@ repos:
     -   id: pylint
         exclude: ^wip/,^test.py
         files: ^kglab/
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.0.0
+    hooks:
+    -   id: codespell # spell-check source code
+        args: ["-L", "wit"] # comma separated list of words to ignore.
+        exclude: ^examples\/|.*\.ipynb
+        language: python
+        types: [text]

--- a/pylintrc
+++ b/pylintrc
@@ -55,7 +55,7 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once). You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes

--- a/wip/entropy.ipynb
+++ b/wip/entropy.ipynb
@@ -239,7 +239,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also use this library to construct a specific shape programatically, e.g., a recipe:"
+    "We can also use this library to construct a specific shape programmatically, e.g., a recipe:"
    ]
   },
   {

--- a/wip/nn2.ipynb
+++ b/wip/nn2.ipynb
@@ -220,7 +220,7 @@
     "        for w in range(-window_size, window_size + 1):\n",
     "            context_word_pos = center_word_pos + w\n",
     "            \n",
-    "            # make soure not jump out sentence\n",
+    "            # make sure not jump out sentence\n",
     "            if context_word_pos < 0 or context_word_pos >= len(indices) or center_word_pos == context_word_pos:\n",
     "                continue\n",
     "            \n",


### PR DESCRIPTION
Hello!

@ceteri @louisguitton 
I'm sure this PR will look somewhat familiar to you, feel free to skim it, as I used my PR from `pytextrank` as a template.

# Pull request overview
- Renamed `.github/workflows/docker-demo.yml` to `.github/workflows/ci.yml`.
- Add `pre-commit` to `.github/workflows/docker-demo.yml` to run on every push, pull request or manually through the Actions tab on GitHub.
- Add `codespell` to `pre-commit`.
  - Fixed three simple spelling mistakes reported by `codespell`.
- Resolved all failing `pre-commit` warnings.

---

Now, let's talk about what I've done:

## Renamed docker-demo.yml to ci.yml, and updating it
The updated `.github/workflows/ci.yml` file works the same as before, with the one addition: It now also runs `pre-commit`. The renaming was a personal choice. It matches the style used for `pytextrank`, and it feels more professional than a name that includes "demo".

It does so whenever someone pushes, creates a pull request, or uses the button in the GitHub Actions pane. 

Note that `pre-commit` in particular is very strict. I'm sure you know this. But it will cause the CI to fail if there's a typo in a comment, a single pylint warning, a security warning, a failing test, etc. This could prevent pull requests from being merged until these warnings are resolved. However, this might be exactly what you are after.

Note: The first execution of this workflow took me approximately 8.5 minutes. This time includes 3 minutes for caching the docker. All subsequent executions (I presume, I've only tested one extra run) take less than 5 minutes. You can see the timings [here](https://github.com/tomaarsen/kglab/actions).

To see the exact output generated, click [here](https://github.com/tomaarsen/kglab/runs/2736447476?check_suite_focus=true).

## Codespell
I've added `codespell` to the `pre-commit` config. The outputs before applying the changes in this PR include:
* Some "typos" in the output sections of Jupyter Notebooks. 
  * These warnings were removed by excluding Jupyter Notebooks from being checked.
* Also some typos in the non-output section of Jupyter Notebooks.
  * These were manually checked and removed, as can be seen in the commit history, before Jupyter Notebooks were removed from being checked by codespell.
* `wit` in `what.md`. Used in the context of `"To wit, ..."`.
  * I've added `wit` as an allowed word to fix this.
* `reenabled => re-enabled` in `pylintrc`
  * I've simply fixed this by adding the hyphen.

## Resolving `pre-commit` warnings.
After solving the warnings from `codespell`, some more changes needed to be made to remove all `pre-commit` warnings. In particular:
* Apply the fixes described in the Codespell section above.
* Exclude the `bin` folder from `bandit`. This folder contains some flask code to launch a sample website - and has debugging enabled. According to `bandit`, this is a security flaw. Clearly, this is not meant for production, and does not need to be tested for security flaws.
* Exclude all tests run on `dat`. Clearly, this folder simply holds data, and we don't wish to spell-check this raw data, or verify that these files have the correct shebangs.
  * The `check-executables-have-shebangs` hook complained that `dat/recipes.csv` is executable, without having a correct shebang. Clearly, we don't need this hook to check data files.

## What now?
All tests, like before, pass. In addition, the CI passes, meaning that all elements of `pre-commit` pass. I would recommend looking over my changes, and looking at my last [GitHub Actions CI run](https://github.com/tomaarsen/kglab/runs/2736447476?check_suite_focus=true). I do recognise that some people prefer testing on their own machine, in which case you can roughly follow:
```
# Clone my repo
git clone https://github.com/tomaarsen/kglab
cd kglab

# Set up a virtualenvironment (Note, this may differ depending on your OS, I don't need to tell you this)
python -m venv venv
.env39/Scripts/Activate.ps1

# Install requirements
pip install -r requirements.txt
pip install -r requirements-dev.txt

# Run pre-commit on all files
pre-commit run -a

# And then delete the new folder when you've verified that everything works.
```
You'll see that `pre-commit` runs without any issues, and this is a big part of what the CI will be doing (alongside running `pytest`). 
Furthermore, if you choose to merge this PR, feel free to add me as a contributor on your README.

---

Lastly, you may need to enable GitHub Actions somewhere within the repository settings (Settings -> Actions -> Actions Permissions)

Let me know if you need anything else from me,

- Tom Aarsen