### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@
 [![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/DerwenAI/kglab.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/DerwenAI/kglab/context:python)
 ![CI](https://github.com/DerwenAI/kglab/workflows/CI/badge.svg)
+![downloads](https://img.shields.io/pypi/dm/kglab)
+![sponsor](https://img.shields.io/github/sponsors/ceteri)
 
-Welcome to *graph-based data science*:
+Welcome to *graph data science*:
 <https://derwen.ai/docs/kgl/>
 
 The **kglab** library provides a simple abstraction layer in Python

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,6 +12,7 @@
 2021-11-26
 
   * further testing/config for NVIDIA GPUs
+  * fixes for Snyk security advisories
   * update to `RDFlib` 6.x, removing use of `json-ld` plugin
   * use `nbmake` to add test coverage of example notebooks into the CI pipeline; kudos @Mec-iS
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -96,6 +96,13 @@ bash <(curl -s https://codecov.io/bash) -t @.cc_token
 Test coverage reports can be viewed at
 <https://codecov.io/gh/DerwenAI/kglab>
 
+The CI pipeline will test automatically for each pull request,
+although to run these tests manually:
+```
+python3 ./test.py
+python3 -m pytest --nbmake examples/
+```
+
 
 ## Online Documentation
 

--- a/examples/ex2_0.ipynb
+++ b/examples/ex2_0.ipynb
@@ -138,6 +138,11 @@
        "      <td>skos</td>\n",
        "      <td>http://www.w3.org/2004/02/skos/core#</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>xml</td>\n",
+       "      <td>http://www.w3.org/XML/1998/namespace</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
@@ -154,7 +159,8 @@
        "7      xsd            http://www.w3.org/2001/XMLSchema#\n",
        "8      wtm                  http://purl.org/heals/food/\n",
        "9      ind            http://purl.org/heals/ingredient/\n",
-       "10    skos         http://www.w3.org/2004/02/skos/core#"
+       "10    skos         http://www.w3.org/2004/02/skos/core#\n",
+       "11     xml         http://www.w3.org/XML/1998/namespace"
       ]
      },
      "execution_count": 3,
@@ -440,7 +446,7 @@
        "        "
       ],
       "text/plain": [
-       "<IPython.lib.display.IFrame at 0x7f942b1bbc10>"
+       "<IPython.lib.display.IFrame at 0x7fcd3eac2310>"
       ]
      },
      "execution_count": 7,
@@ -566,29 +572,29 @@
        "      <th>0</th>\n",
        "      <td>tmp.ttl</td>\n",
        "      <td>56780</td>\n",
-       "      <td>129.53</td>\n",
-       "      <td>0.002281</td>\n",
+       "      <td>116.03</td>\n",
+       "      <td>0.002044</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>tmp.xml</td>\n",
        "      <td>159397</td>\n",
-       "      <td>40.82</td>\n",
-       "      <td>0.000256</td>\n",
+       "      <td>42.04</td>\n",
+       "      <td>0.000264</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>tmp.jsonld</td>\n",
-       "      <td>131850</td>\n",
-       "      <td>88.18</td>\n",
-       "      <td>0.000669</td>\n",
+       "      <td>131901</td>\n",
+       "      <td>92.12</td>\n",
+       "      <td>0.000698</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>tmp.parquet</td>\n",
-       "      <td>14743</td>\n",
-       "      <td>37.17</td>\n",
-       "      <td>0.002521</td>\n",
+       "      <td>14710</td>\n",
+       "      <td>37.76</td>\n",
+       "      <td>0.002567</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -596,10 +602,10 @@
       ],
       "text/plain": [
        "     file_path  file_size  write_time  ms_per_byte\n",
-       "0      tmp.ttl      56780      129.53     0.002281\n",
-       "1      tmp.xml     159397       40.82     0.000256\n",
-       "2   tmp.jsonld     131850       88.18     0.000669\n",
-       "3  tmp.parquet      14743       37.17     0.002521"
+       "0      tmp.ttl      56780      116.03     0.002044\n",
+       "1      tmp.xml     159397       42.04     0.000264\n",
+       "2   tmp.jsonld     131901       92.12     0.000698\n",
+       "3  tmp.parquet      14710       37.76     0.002567"
       ]
      },
      "execution_count": 10,

--- a/kglab/kglab.py
+++ b/kglab/kglab.py
@@ -225,6 +225,11 @@ a `dict` describing the namespaces in this RDF graph
             for prefix, ns in self._ns.items()
         }
 
+        nm = self._g.namespace_manager
+
+        for prefix, uri in nm.namespaces():
+            ns_dict[prefix] = str(uri)
+
         return ns_dict
 
 
@@ -244,7 +249,7 @@ a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/ap
                 col_names[0]: prefix,
                 col_names[1]: str(ns),
             }
-            for prefix, ns in self._ns.items()
+            for prefix, ns in self.get_ns_dict().items()
         ]
 
         if self.use_gpus:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ codespell
 coverage
 flask
 grayskull
-jupyterlab
+jupyterlab >= 3.1.4
 mkdocs-git-revision-date-plugin
 mkdocs-material
 mknotebooks


### PR DESCRIPTION
### Current behaviour
fixed the returned namespaces #199

### New expected behaviour
should have both the explicitly added ones (via `namespaces` init parameter) as well as the implicitly added ones which came in through file loads.

### Change logs

 - modified `kglab.KnowledgeGraph.get_ns_dict()` to have this corrected behavior
 - modified `kglab.KnowledgeGraph.describe_ns()` to use `get_ns_dict()` internally