### PR TITLE
update abort_on_error to abort_on_first for pyshacl

### DIFF
--- a/docs/ref.md
+++ b/docs/ref.md
@@ -550,7 +550,7 @@ PyVis network object, to be rendered
 [*\[source\]*](https://github.com/DerwenAI/kglab/blob/main/kglab/kglab.py#L1127)
 
 ```python
-validate(shacl_graph=None, shacl_graph_format=None, ont_graph=None, ont_graph_format=None, advanced=False, inference=None, inplace=True, abort_on_error=None, **kwargs)
+validate(shacl_graph=None, shacl_graph_format=None, ont_graph=None, ont_graph_format=None, advanced=False, inference=None, inplace=True, abort_on_first=None, **kwargs)
 ```
 Wrapper for [`pyshacl.validate()`](https://github.com/RDFLib/pySHACL) for validating the RDF graph using rules expressed in the [SHACL](https://www.w3.org/TR/shacl/) (Shapes Constraint Language).
 
@@ -574,7 +574,7 @@ prior to validation, run OWL2 RL profile-based expansion of the RDF graph based 
   * `inplace` : `typing.Union[bool, NoneType]`  
 when enabled, do not clone the RDF graph prior to inference/expansion, just manipulate it in-place
 
-  * `abort_on_error` : `typing.Union[bool, NoneType]`  
+  * `abort_on_first` : `typing.Union[bool, NoneType]`  
 abort validation on the first error
 
   * *returns* : `typing.Tuple[bool, KnowledgeGraph, str]`  

--- a/kglab/kglab.py
+++ b/kglab/kglab.py
@@ -1134,7 +1134,7 @@ PyVis network object, to be rendered
         advanced: typing.Optional[bool] = False,
         inference: typing.Optional[str] = None,
         inplace:typing.Optional[bool] = True,
-        abort_on_error: typing.Optional[bool] = None,
+        abort_on_first: typing.Optional[bool] = None,
         **kwargs: typing.Any,
         ) -> typing.Tuple[bool, "KnowledgeGraph", str]:
         """
@@ -1161,7 +1161,7 @@ prior to validation, run OWL2 RL profile-based expansion of the RDF graph based 
     inplace:
 when enabled, do not clone the RDF graph prior to inference/expansion, just manipulate it in-place
 
-    abort_on_error:
+    abort_on_first:
 abort validation on the first error
 
     returns:
@@ -1176,7 +1176,7 @@ a tuple of `conforms` (RDF graph passes the validation rules) + `report_graph` (
             advanced=advanced,
             inference=inference,
             inplace=inplace,
-            abort_on_error=abort_on_error,
+            abort_on_first=abort_on_first,
             serialize_report_graph="ttl",
             **chocolate.filter_args(kwargs, pyshacl.validate),
             )


### PR DESCRIPTION
Pull request in reference to https://github.com/DerwenAI/kglab/issues/211 

### Current behaviour
Running pyshacl return a warning

Usage of abort_on_error is deprecated. Use abort_on_first instead.

Which is annoying when processing 1K files via dask :)

### New expected behaviour
no such warning


### Change logs
 #### Fixed

* simple update from abort_on_error to abort_on_first in two files

