### PR TITLE
docker build on GH CI behaves differently

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,12 +33,12 @@ RUN set -eux; \
 FROM libs as kglab
 
 ## copy source
-COPY ./requirements*.txt /opt/kglab
 COPY ./kglab /opt/kglab/kglab
 COPY ./dat /opt/kglab/dat
 COPY ./examples /opt/kglab/examples
-COPY ./test.py /opt/kglab
-COPY ./sample.py /opt/kglab
+COPY ./requirements*.txt /opt/kglab/
+COPY ./test.py /opt/kglab/
+COPY ./sample.py /opt/kglab/
 
 ## create a known user ID
 RUN set -eux; \

--- a/docker/Dockerfile.common
+++ b/docker/Dockerfile.common
@@ -33,12 +33,12 @@ RUN set -eux; \
 FROM libs as kglab
 
 ## copy source
-COPY ./requirements*.txt /opt/kglab
 COPY ./kglab /opt/kglab/kglab
 COPY ./dat /opt/kglab/dat
 COPY ./examples /opt/kglab/examples
-COPY ./test.py /opt/kglab
-COPY ./sample.py /opt/kglab
+COPY ./requirements*.txt /opt/kglab/
+COPY ./test.py /opt/kglab/
+COPY ./sample.py /opt/kglab/
 
 ## create a known user ID
 RUN set -eux; \

--- a/docker/testsuite.Dockerfile
+++ b/docker/testsuite.Dockerfile
@@ -33,12 +33,12 @@ RUN set -eux; \
 FROM libs as kglab
 
 ## copy source
-COPY ./requirements*.txt /opt/kglab
 COPY ./kglab /opt/kglab/kglab
 COPY ./dat /opt/kglab/dat
 COPY ./examples /opt/kglab/examples
-COPY ./test.py /opt/kglab
-COPY ./sample.py /opt/kglab
+COPY ./requirements*.txt /opt/kglab/
+COPY ./test.py /opt/kglab/
+COPY ./sample.py /opt/kglab/
 
 ## create a known user ID
 RUN set -eux; \


### PR DESCRIPTION
check for lack of trailing `/` when copying multiple files (globs) into src directories with a `COPY` command