### PR TITLE
Auto adjust window size when visualizing the graph #257

### DIFF
--- a/kglab/subg.py
+++ b/kglab/subg.py
@@ -436,6 +436,11 @@ text label for the node
     style:
 optional style dictionary
         """
+        if notebook == False:
+            import pyautogui
+            wid, hei= pyautogui.size()
+            pyvis_graph = pyvis.network.Network(width='{}px'.format(wid), height='{}px'.format(hei), notebook=notebook)
+
         if not style:
             style = {}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,3 +26,4 @@ types-python-dateutil >= 2.8
 types-requests >= 2.27
 wheel >= 0.37
 xmltodict >= 0.12
+pyautogui >= 0.9.53


### PR DESCRIPTION
### Current behaviour
Original codes use default height and width in pyvis.network.Network

### New expected behaviour
The new codes use window width and height when notebook is False

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 --> added the following lines after line 438
        if notebook == False:
            import pyautogui
            wid, hei= pyautogui.size()
            pyvis_graph = pyvis.network.Network(width='{}px'.format(wid), height='{}px'.format(hei), notebook=notebook)
<!-- - Feature 2 --> added pyautogui in requirements


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->
#257


<!-- #### Removed -->
<!-- Edit these points below to describe the removed features with this PR -->
<!-- - Deprecated feature 1 -->