### PR TITLE
Create querying mixin

### DIFF
--- a/kglab/kglab.py
+++ b/kglab/kglab.py
@@ -39,6 +39,7 @@ from kglab.gpviz import GPViz
 from kglab.util import get_gpu_count
 from kglab.version import _check_version
 import kglab.query.sparql
+from .querying import QueryingMixin
 
 
 ## pre-constructor set-up
@@ -48,7 +49,7 @@ if get_gpu_count() > 0:
     import cudf  # type: ignore  # pylint: disable=E0401
 
 
-class KnowledgeGraph:
+class KnowledgeGraph(QueryingMixin):
     """
 This is the primary class used to represent RDF graphs, on which the other classes are dependent.
 See <https://derwen.ai/docs/kgl/concepts/#knowledge-graph>
@@ -1035,188 +1036,6 @@ a list of identifiers for the top-level nodes added from the Roam Research graph
             ]
 
         return uid_list
-
-
-    ######################################################################
-    ## SPARQL queries
-
-    def query (
-        self,
-        sparql: str,
-        *,
-        bindings: dict = None,
-        ) -> typing.Iterable:
-        """
-Wrapper for [`rdflib.Graph.query()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=query#rdflib.Graph.query) to perform a SPARQL query on the RDF graph.
-
-    sparql:
-text for the SPARQL query
-
-    bindings:
-initial variable bindings
-
-    yields:
-[`rdflib.query.ResultRow`](https://rdflib.readthedocs.io/en/stable/_modules/rdflib/query.html?highlight=ResultRow#) named tuples, to iterate through the query result set
-        """
-        if not bindings:
-            bindings = {}
-
-        for row in self._g.query(
-                sparql,
-                initBindings=bindings,
-            ):
-            yield row
-
-
-    def query_as_df (
-        self,
-        sparql: str,
-        *,
-        bindings: dict = None,
-        simplify: bool = True,
-        pythonify: bool = True,
-        ) -> pd.DataFrame:
-        """
-Wrapper for [`rdflib.Graph.query()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=query#rdflib.Graph.query) to perform a SPARQL query on the RDF graph.
-
-    sparql:
-text for the SPARQL query
-
-    bindings:
-initial variable bindings
-
-    simplify:
-convert terms in each row of the result set into a readable representation for each term, using N3 format
-
-    pythonify:
-convert instances of [`rdflib.term.Literal`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Literal#rdflib.term.Identifier) to their Python literal representation
-
-    returns:
-the query result set represented as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html); uses the [RAPIDS `cuDF` library](https://docs.rapids.ai/api/cudf/stable/) if GPUs are enabled
-        """
-        if not bindings:
-            bindings = {}
-
-        row_iter = self._g.query(sparql, initBindings=bindings)
-
-        if simplify:
-            rows_list = [ self.n3fy_row(r.asdict(), pythonify=pythonify) for r in row_iter ]
-        else:
-            rows_list = [ r.asdict() for r in row_iter ]
-
-        if self.use_gpus:
-            df = cudf.DataFrame(rows_list)
-        else:
-            df = pd.DataFrame(rows_list)
-
-        return df
-
-
-    def visualize_query (
-        self,
-        sparql: str,
-        *,
-        notebook: bool = False,
-        ) -> pyvis.network.Network:
-        """
-Visualize the given SPARQL query as a [`pyvis.network.Network`](https://pyvis.readthedocs.io/en/latest/documentation.html#pyvis.network.Network)
-
-    sparql:
-input SPARQL query to be visualized
-
-    notebook:
-optional boolean flag, whether to initialize the PyVis graph to render within a notebook; defaults to `False`
-
-    returns:
-PyVis network object, to be rendered
-        """
-        return GPViz(sparql, self._ns).visualize_query(notebook=notebook)
-
-
-    def n3fy (
-        self,
-        node: RDF_Node,
-        *,
-        pythonify: bool = True,
-        ) -> typing.Any:
-        """
-Wrapper for RDFlib [`n3()`](https://rdflib.readthedocs.io/en/stable/utilities.html?highlight=n3#serializing-a-single-term-to-n3) and [`toPython()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=toPython#rdflib.Variable.toPython) to serialize a node into a human-readable representation using N3 format.
-
-    node:
-must be a [`rdflib.term.Node`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Node#rdflib.term.Node)
-
-    pythonify:
-flag to force instances of [`rdflib.term.Literal`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Literal#rdflib.term.Identifier) to their Python literal representation
-
-    returns:
-text (or Python objects) for the serialized node
-        """
-        if pythonify and isinstance(node, rdflib.term.Literal):
-            serialized = node.toPython()
-        else:
-            serialized = node.n3(self._g.namespace_manager)  # type: ignore
-
-        return serialized
-
-
-    def n3fy_row (
-        self,
-        row_dict: dict,
-        *,
-        pythonify: bool = True,
-        ) -> dict:
-        """
-Wrapper for RDFlib [`n3()`](https://rdflib.readthedocs.io/en/stable/utilities.html?highlight=n3#serializing-a-single-term-to-n3) and [`toPython()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=toPython#rdflib.Variable.toPython) to serialize one row of a result set from a SPARQL query into a human-readable representation for each term using N3 format.
-
-    row_dict:
-one row of a SPARQL query results, as a `dict`
-
-    pythonify:
-flag to force instances of [`rdflib.term.Literal`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Literal#rdflib.term.Identifier) to their Python literal representation
-
-    returns:
-a dictionary of serialized row bindings
-        """
-        bindings = {
-            k: self.n3fy(v, pythonify=pythonify)
-            for k, v in row_dict.items()
-        }
-
-        return bindings
-
-
-    @classmethod
-    def unbind_sparql (
-        cls,
-        sparql: str,
-        bindings: dict,
-        *,
-        preamble: str = "",
-        ) -> str:
-        """
-Substitute the _binding variables_ into the text of a SPARQL query,
-to obviate the need for binding variables specified separately.
-This can be helpful for debugging, or for some query engines that
-may not have full SPARQL support yet.
-
-    sparql:
-text for the SPARQL query
-
-    bindings:
-variable bindings
-
-    returns:
-a string of the expanded SPARQL query
-        """
-        sparql_meta, sparql_body = re.split(r"\s*WHERE\s*\{", sparql, maxsplit=1)
-
-        for var in sorted(bindings.keys(), key=lambda x: len(x), reverse=True):  # pylint: disable=W0108
-            pattern = re.compile(r"(\?" + var + r")(\W)")  # pylint: disable=W1401
-            bind_val = "<" + str(bindings[var]) + ">\\2"
-            sparql_body = re.sub(pattern, bind_val, sparql_body)
-
-        result = "".join([preamble, sparql_meta, " WHERE {", sparql_body]).strip()
-        return result
 
 
     ######################################################################

--- a/kglab/querying.py
+++ b/kglab/querying.py
@@ -1,7 +1,7 @@
 # see license https://github.com/DerwenAI/kglab#license-and-copyright
 
 """
-Mixin definition for `kglab` querying
+Mixin definition for `KnowledgeGraph` querying functionalities
 """
 
 ## Python standard libraries
@@ -9,14 +9,13 @@ import re
 import typing
 
 ### third-parties libraries
-from icecream import ic  # type: ignore  # pylint: disable=E0401
-import dateutil.parser as dup  # pylint: disable=E0401
-import pandas as pd  # type: ignore  # pylint: disable=E0401
-import pyvis  # type: ignore  # pylint: disable=E0401
+from icecream import ic  # type: ignore
+import pandas as pd  # type: ignore
+import pyvis  # type: ignore
 
-import rdflib  # type: ignore  # pylint: disable=E0401
-import rdflib.plugin  # type: ignore  # pylint: disable=E0401
-import rdflib.plugins.parsers.notation3 as rdf_n3  # type: ignore  # pylint: disable=E0401
+import rdflib  # type: ignore
+import rdflib.plugin  # type: ignore
+import rdflib.plugins.parsers.notation3 as rdf_n3  # type: ignore
 
 ## kglab - core classes
 from kglab.pkg_types import RDF_Node

--- a/kglab/querying.py
+++ b/kglab/querying.py
@@ -1,0 +1,222 @@
+# see license https://github.com/DerwenAI/kglab#license-and-copyright
+
+"""
+Mixin definition for `kglab` querying
+"""
+
+## Python standard libraries
+import re
+import typing
+
+### third-parties libraries
+from icecream import ic  # type: ignore  # pylint: disable=E0401
+import dateutil.parser as dup  # pylint: disable=E0401
+import pandas as pd  # type: ignore  # pylint: disable=E0401
+import pyvis  # type: ignore  # pylint: disable=E0401
+
+import rdflib  # type: ignore  # pylint: disable=E0401
+import rdflib.plugin  # type: ignore  # pylint: disable=E0401
+import rdflib.plugins.parsers.notation3 as rdf_n3  # type: ignore  # pylint: disable=E0401
+
+## kglab - core classes
+from kglab.pkg_types import RDF_Node
+from kglab.gpviz import GPViz
+from kglab.util import get_gpu_count
+from kglab.version import _check_version
+
+
+## pre-constructor set-up
+_check_version()
+
+if get_gpu_count() > 0:
+    import cudf  # type: ignore  # pylint: disable=E0401
+
+
+class QueryingMixin:
+    """
+This class implements querying for `KnowledgeGraph`
+
+Core feature areas include:
+  * SPARQL querying
+  * Cypher querying (future)
+    """
+    ######################################################################
+    ## SPARQL queries
+
+    def query (
+        self,
+        sparql: str,
+        *,
+        bindings: dict = None,
+        ) -> typing.Iterable:
+        """
+Wrapper for [`rdflib.Graph.query()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=query#rdflib.Graph.query) to perform a SPARQL query on the RDF graph.
+
+    sparql:
+text for the SPARQL query
+
+    bindings:
+initial variable bindings
+
+    yields:
+[`rdflib.query.ResultRow`](https://rdflib.readthedocs.io/en/stable/_modules/rdflib/query.html?highlight=ResultRow#) named tuples, to iterate through the query result set
+        """
+        if not bindings:
+            bindings = {}
+
+        for row in self._g.query(
+                sparql,
+                initBindings=bindings,
+            ):
+            yield row
+
+
+    def query_as_df (
+        self,
+        sparql: str,
+        *,
+        bindings: dict = None,
+        simplify: bool = True,
+        pythonify: bool = True,
+        ) -> pd.DataFrame:
+        """
+Wrapper for [`rdflib.Graph.query()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=query#rdflib.Graph.query) to perform a SPARQL query on the RDF graph.
+
+    sparql:
+text for the SPARQL query
+
+    bindings:
+initial variable bindings
+
+    simplify:
+convert terms in each row of the result set into a readable representation for each term, using N3 format
+
+    pythonify:
+convert instances of [`rdflib.term.Literal`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Literal#rdflib.term.Identifier) to their Python literal representation
+
+    returns:
+the query result set represented as a [`pandas.DataFrame`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html); uses the [RAPIDS `cuDF` library](https://docs.rapids.ai/api/cudf/stable/) if GPUs are enabled
+        """
+        if not bindings:
+            bindings = {}
+
+        row_iter = self._g.query(sparql, initBindings=bindings)
+
+        if simplify:
+            rows_list = [ self.n3fy_row(r.asdict(), pythonify=pythonify) for r in row_iter ]
+        else:
+            rows_list = [ r.asdict() for r in row_iter ]
+
+        if self.use_gpus:
+            df = cudf.DataFrame(rows_list)
+        else:
+            df = pd.DataFrame(rows_list)
+
+        return df
+
+
+    def visualize_query (
+        self,
+        sparql: str,
+        *,
+        notebook: bool = False,
+        ) -> pyvis.network.Network:
+        """
+Visualize the given SPARQL query as a [`pyvis.network.Network`](https://pyvis.readthedocs.io/en/latest/documentation.html#pyvis.network.Network)
+
+    sparql:
+input SPARQL query to be visualized
+
+    notebook:
+optional boolean flag, whether to initialize the PyVis graph to render within a notebook; defaults to `False`
+
+    returns:
+PyVis network object, to be rendered
+        """
+        return GPViz(sparql, self._ns).visualize_query(notebook=notebook)
+
+
+    def n3fy (
+        self,
+        node: RDF_Node,
+        *,
+        pythonify: bool = True,
+        ) -> typing.Any:
+        """
+Wrapper for RDFlib [`n3()`](https://rdflib.readthedocs.io/en/stable/utilities.html?highlight=n3#serializing-a-single-term-to-n3) and [`toPython()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=toPython#rdflib.Variable.toPython) to serialize a node into a human-readable representation using N3 format.
+
+    node:
+must be a [`rdflib.term.Node`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Node#rdflib.term.Node)
+
+    pythonify:
+flag to force instances of [`rdflib.term.Literal`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Literal#rdflib.term.Identifier) to their Python literal representation
+
+    returns:
+text (or Python objects) for the serialized node
+        """
+        if pythonify and isinstance(node, rdflib.term.Literal):
+            serialized = node.toPython()
+        else:
+            serialized = node.n3(self._g.namespace_manager)  # type: ignore
+
+        return serialized
+
+
+    def n3fy_row (
+        self,
+        row_dict: dict,
+        *,
+        pythonify: bool = True,
+        ) -> dict:
+        """
+Wrapper for RDFlib [`n3()`](https://rdflib.readthedocs.io/en/stable/utilities.html?highlight=n3#serializing-a-single-term-to-n3) and [`toPython()`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=toPython#rdflib.Variable.toPython) to serialize one row of a result set from a SPARQL query into a human-readable representation for each term using N3 format.
+
+    row_dict:
+one row of a SPARQL query results, as a `dict`
+
+    pythonify:
+flag to force instances of [`rdflib.term.Literal`](https://rdflib.readthedocs.io/en/stable/apidocs/rdflib.html?highlight=Literal#rdflib.term.Identifier) to their Python literal representation
+
+    returns:
+a dictionary of serialized row bindings
+        """
+        bindings = {
+            k: self.n3fy(v, pythonify=pythonify)
+            for k, v in row_dict.items()
+        }
+
+        return bindings
+
+
+    @classmethod
+    def unbind_sparql (
+        cls,
+        sparql: str,
+        bindings: dict,
+        *,
+        preamble: str = "",
+        ) -> str:
+        """
+Substitute the _binding variables_ into the text of a SPARQL query,
+to obviate the need for binding variables specified separately.
+This can be helpful for debugging, or for some query engines that
+may not have full SPARQL support yet.
+
+    sparql:
+text for the SPARQL query
+
+    bindings:
+variable bindings
+
+    returns:
+a string of the expanded SPARQL query
+        """
+        sparql_meta, sparql_body = re.split(r"\s*WHERE\s*\{", sparql, maxsplit=1)
+
+        for var in sorted(bindings.keys(), key=lambda x: len(x), reverse=True):  # pylint: disable=W0108
+            pattern = re.compile(r"(\?" + var + r")(\W)")  # pylint: disable=W1401
+            bind_val = "<" + str(bindings[var]) + ">\\2"
+            sparql_body = re.sub(pattern, bind_val, sparql_body)
+
+        result = "".join([preamble, sparql_meta, " WHERE {", sparql_body]).strip()
+        return result

--- a/pylintrc
+++ b/pylintrc
@@ -60,16 +60,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use "--disable=all --enable=classes
 # --disable=W".
-disable=C0103,
-	C0114,
-	C0301,
-	C0411,
-	C0413,
-        C0415,
-	R0401,
-	R0801,
-	W0622,
-	W0707
+disable=R0903,C0103,C0114,C0301,C0411,C0413,C0415,R0401,R0801,W0622,W0707,E0401
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -106,7 +97,7 @@ score=yes
 [REFACTORING]
 
 # Maximum number of nested blocks for function / method body
-max-nested-blocks=5
+max-nested-blocks=10
 
 # Complete name of functions that never returns. When checking for
 # inconsistent-return-statements if a never returning function is called then


### PR DESCRIPTION
### Current behaviour
All the methods are stacked in the `kglab` module and it makes it difficult to handle. 

### New expected behaviour
Implement mixins for different functionalities in different modules:
  * namespace management (ontology, controlled vocabularies)
  * graph construction
  * serialization
  * ~SPARQL querying~ implemented by this PR
  * SHACL validation
  * inference based on OWL-RL, RDFS, SKOSby creating a mixin 

@ceteri let me know if this is ok. The only problem I see is that the credits for writing the code are moved to the developer that created the mixin. So if you want to keep the credits to the developer that wrote the code in the first place he/she will have to create the mixins by himself. Let me know if this is a problem.

### Change logs

* Add `querying` module that incapsulates querying for `KnowledgeGraph`
* Move `querying` out of `KnowledgeGraph` into `QueryingMixin`
