### PR TITLE
Prefix strings with `r` to avoid `DeprecationWarning` and `W1401`

### DIFF
--- a/kglab/query/sparql.py
+++ b/kglab/query/sparql.py
@@ -192,7 +192,7 @@ a string of the expanded SPARQL query
         sparql_meta, sparql_body = re.split(r"\s*WHERE\s*\{", query, maxsplit=1)
 
         for var in sorted(bindings.keys(), key=lambda x: len(x), reverse=True):  # pylint: disable=W0108
-            pattern = re.compile("(\?" + var + ")(\W)")  # pylint: disable=W1401
+            pattern = re.compile(r"(\?" + var + r")(\W)")
             bind_val = "<" + str(bindings[var]) + ">\\2"
             sparql_body = re.sub(pattern, bind_val, sparql_body)
 


### PR DESCRIPTION
I noticed some warnings in the CI runs for #263:
```python
=============================== warnings summary ===============================
kglab/query/sparql.py:195
  /opt/kglab/kglab/query/sparql.py:195: DeprecationWarning: invalid escape sequence \?
    pattern = re.compile("(\?" + var + ")(\W)")  # pylint: disable=W1401

kglab/query/sparql.py:195
  /opt/kglab/kglab/query/sparql.py:195: DeprecationWarning: invalid escape sequence \W
    pattern = re.compile("(\?" + var + ")(\W)")  # pylint: disable=W1401
```

So I've updated this line to use the `r` string prefix instead.

- Tom Aarsen