### PR TITLE
restore the missing headers from previous merge conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
 name = "kglab"
 version = "0.6.7"
 authors = [


### PR DESCRIPTION
this now builds correctly with `python3 -m pip install -e .`